### PR TITLE
Automatically find the most common LAPACK dlls in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,15 @@ You can link against a different LAPACK implementation by a combination of:
 
 * changing the path for linked libraries (use
   [`--clibdir`](https://nim-lang.org/docs/nimc.html#compiler-usage-command-line-switches)
-  for this)
-* using the `--define:lapack` flag. By default, the system tries to load a LAPACK
-  library called `lapack`, which translates into something called `lapack.dll`
-  or `liblapack.so` according to the underling operating system. To link,
-  say, the library `libopenblas.so.3` on Linux, you should pass to Nim the
-  option `--define:lapack=openblas`.
+  for this).
+* using the `--define:lapack` flag. By default (i.e. if you don't set this flag), the system
+  tries to load a LAPACK library by looking for the most common LAPACK library file names according
+  to the underling operating system (e.g. `lapack.dll`, `openblas.dll`, `libopenblas.dll`,
+  `mkl_intel_lp64.dll` in Windows or `liblapack.so` on Linux, etc).
+  However, if you want to link to one specific library, such as, say, the library `libopenblas.so.3`
+  on Linux you should pass to Nim the option `--define:lapack=openblas`. Note the missing `lib` prefix
+  and `.so` suffix, which nimlapack adds automatically (similarly on windows you should not include
+  the `.dll` extension when setting this flag).
 
 See the tasks inside [nimblas.nimble](https://github.com/andreaferretti/nimlapack/blob/master/nimlapack.nimble)
 for a few examples.
@@ -31,7 +34,9 @@ for a few examples.
 Packages for various LAPACK implementations are available from the package
 managers of many Linux distributions. On OSX one can add the brew formulas
 from [Homebrew Science](https://github.com/Homebrew/homebrew-science), such
-as `brew install homebrew/science/openblas`.
+as `brew install homebrew/science/openblas`. On Windows you can download pre-built
+binaries from the [OpenBLAS github repository](https://github.com/OpenMathLib/OpenBLAS/releases)
+and add the library folder to your PATH or copy it into your executable folder.
 
 You may also need to add suitable paths for the includes and library dirs.
 On OSX, this should do the trick

--- a/nimlapack.nim
+++ b/nimlapack.nim
@@ -7,7 +7,7 @@ elif defined(macosx):
   const
     libSuffix = ".dylib"
     libPrefix = "lib"
-    lapack {.strdefine.} = "lapack"
+    lapack {.strdefine.} = "(lapack|openblas)"
 else:
   const
     libSuffix = ".so(||.3|.2|.1|.0)"

--- a/nimlapack.nim
+++ b/nimlapack.nim
@@ -1,18 +1,20 @@
 when defined(windows):
   const
     libSuffix = ".dll"
-    libPrefix = ""
+    libPrefix = "(|lib)"
+    lapack {.strdefine.} = "(lapack|openblas|mkl_intel_lp64)"
 elif defined(macosx):
   const
     libSuffix = ".dylib"
     libPrefix = "lib"
+    lapack {.strdefine.} = "lapack"
 else:
   const
     libSuffix = ".so(||.3|.2|.1|.0)"
     libPrefix = "lib"
+    lapack {.strdefine.} = "lapack"
 
 const
-  lapack {.strdefine.} = "lapack"
   libName = libPrefix & lapack & libSuffix
 
 {.hint: "Using LAPACK library with name: " & libName .}


### PR DESCRIPTION
This uses the fact that dynlib supports patterns to look for the most common LAPACK dll names when loading the LAPACK library.